### PR TITLE
Promise tracker with weak reference

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -243,7 +243,7 @@ function $$QProvider() {
  */
 function qFactory(nextTick, exceptionHandler) {
   var $qMinErr = minErr('$q', TypeError);
-  window.promises = window.promises || {};
+  window.promises = window.promises || {pending: new Map()};
   window.promises.angular = window.promises.angular || {pendingCount: 0};
   
   /**
@@ -271,6 +271,10 @@ function qFactory(nextTick, exceptionHandler) {
     this.trackPromise = typeof(trackPromise) !== 'undefined' ? trackPromise : true;
     if(this.trackPromise) {
       window.promises.angular.pendingCount++;
+      if(window.desktop && window.WeakREference) {
+        this.key = '_' + Math.random().toString(36).substr(2, 9);
+        window.promises.pending.set(this.key, new window.WeakReference(this));
+      }
     }
   }
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -375,7 +375,7 @@ function qFactory(nextTick, exceptionHandler) {
           if(this.promise.trackPromise) {
             window.promises.angular.pendingCount--;
             if(window.desktop && window.WeakReference) {
-              window.promises.pending.set(this.promise.key, undefined);
+              //window.promises.pending.set(this.promise.key, undefined);
             }
           }
           scheduleProcessQueue(this.promise.$$state);
@@ -411,7 +411,7 @@ function qFactory(nextTick, exceptionHandler) {
         if(this.promise.trackPromise) {
           window.promises.angular.pendingCount--;
           if(window.desktop && window.WeakReference) {
-            window.promises.pending.set(this.promise.key, undefined);
+            //window.promises.pending.set(this.promise.key, undefined);
           }
         }
       }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -243,7 +243,7 @@ function $$QProvider() {
  */
 function qFactory(nextTick, exceptionHandler) {
   var $qMinErr = minErr('$q', TypeError);
-  window.promises = window.promises || {};
+  window.promises = window.promises || {pending: new Map()};
   window.promises.angular = window.promises.angular || {pendingCount: 0};
   
   /**
@@ -271,6 +271,10 @@ function qFactory(nextTick, exceptionHandler) {
     this.trackPromise = typeof(trackPromise) !== 'undefined' ? trackPromise : true;
     if(this.trackPromise) {
       window.promises.angular.pendingCount++;
+      if(window.desktop && window.WeakReference) {
+        this.key = Math.random().toString(36).substr(2, 9);
+        window.promises.pending.set(this.key, new window.WeakReference(this));
+      }
     }
   }
 
@@ -370,6 +374,9 @@ function qFactory(nextTick, exceptionHandler) {
           this.promise.$$state.status = 1;
           if(this.promise.trackPromise) {
             window.promises.angular.pendingCount--;
+            if(window.desktop && window.WeakReference) {
+              window.promises.pending.delete(this.promise.key);
+            }
           }
           scheduleProcessQueue(this.promise.$$state);
         }
@@ -403,6 +410,9 @@ function qFactory(nextTick, exceptionHandler) {
       } finally {
         if(this.promise.trackPromise) {
           window.promises.angular.pendingCount--;
+          if(window.desktop && window.WeakReference) {
+            window.promises.pending.delete(this.promise.key);
+          }
         }
       }
     },

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -271,7 +271,7 @@ function qFactory(nextTick, exceptionHandler) {
     this.trackPromise = typeof(trackPromise) !== 'undefined' ? trackPromise : true;
     if(this.trackPromise) {
       window.promises.angular.pendingCount++;
-      if(window.desktop && window.WeakREference) {
+      if(window.desktop && window.WeakReference) {
         this.key = '_' + Math.random().toString(36).substr(2, 9);
         window.promises.pending.set(this.key, new window.WeakReference(this));
       }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -374,6 +374,9 @@ function qFactory(nextTick, exceptionHandler) {
           this.promise.$$state.status = 1;
           if(this.promise.trackPromise) {
             window.promises.angular.pendingCount--;
+            if(window.desktop && window.WeakReference) {
+              window.promises.pending.set(this.promise.key, undefined);
+            }
           }
           scheduleProcessQueue(this.promise.$$state);
         }
@@ -407,6 +410,9 @@ function qFactory(nextTick, exceptionHandler) {
       } finally {
         if(this.promise.trackPromise) {
           window.promises.angular.pendingCount--;
+          if(window.desktop && window.WeakReference) {
+            window.promises.pending.set(this.promise.key, undefined);
+          }
         }
       }
     },

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -245,7 +245,7 @@ function qFactory(nextTick, exceptionHandler) {
   var $qMinErr = minErr('$q', TypeError);
   window.promises = window.promises || {};
   window.promises.angular = window.promises.angular || {pendingCount: 0};
-
+  
   /**
    * @ngdoc method
    * @name ng.$q#defer

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -401,7 +401,7 @@ function qFactory(nextTick, exceptionHandler) {
         this.promise.$$state.status = 2;
         scheduleProcessQueue(this.promise.$$state);
       } finally {
-        if(this.trackPromise) {
+        if(this.promise.trackPromise) {
           window.promises.angular.pendingCount--;
         }
       }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -243,7 +243,7 @@ function $$QProvider() {
  */
 function qFactory(nextTick, exceptionHandler) {
   var $qMinErr = minErr('$q', TypeError);
-  window.promises = window.promises || {pending: new Map()};
+  window.promises = window.promises || {};
   window.promises.angular = window.promises.angular || {pendingCount: 0};
   
   /**
@@ -271,10 +271,6 @@ function qFactory(nextTick, exceptionHandler) {
     this.trackPromise = typeof(trackPromise) !== 'undefined' ? trackPromise : true;
     if(this.trackPromise) {
       window.promises.angular.pendingCount++;
-      if(window.desktop && window.WeakReference) {
-        this.key = '_' + Math.random().toString(36).substr(2, 9);
-        window.promises.pending.set(this.key, new window.WeakReference(this));
-      }
     }
   }
 
@@ -374,9 +370,6 @@ function qFactory(nextTick, exceptionHandler) {
           this.promise.$$state.status = 1;
           if(this.promise.trackPromise) {
             window.promises.angular.pendingCount--;
-            if(window.desktop && window.WeakReference) {
-              //window.promises.pending.set(this.promise.key, undefined);
-            }
           }
           scheduleProcessQueue(this.promise.$$state);
         }
@@ -410,9 +403,6 @@ function qFactory(nextTick, exceptionHandler) {
       } finally {
         if(this.promise.trackPromise) {
           window.promises.angular.pendingCount--;
-          if(window.desktop && window.WeakReference) {
-            //window.promises.pending.set(this.promise.key, undefined);
-          }
         }
       }
     },


### PR DESCRIPTION
**Do not accept this PR we are still waiting for the WeakReference stuff to work properly in Electron**

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
There are no way to keep track of which promises are lingering / pending if one never resolve/reject a promise he/she creates.

**What is the new behavior (if this is a feature change)?**
A promise counter has been implemented to the angular qFactory that counts the number of pending/lingering promises that have not been resolved. The counter gets incremented whenever a new promise is created, and is decremented as promises are resolved or rejected. 

The counter is accessible through the `window.promises` object.

Examples:
https://plnkr.co/edit/ydki6XZkePEfexqaUQYE