### PR TITLE
Promise Tracker API

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -31,6 +31,7 @@ var angularFiles = {
     'src/ng/location.js',
     'src/ng/log.js',
     'src/ng/parse.js',
+    'src/ng/qPromiseTracker.js',
     'src/ng/q.js',
     'src/ng/raf.js',
     'src/ng/rootScope.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -241,6 +241,7 @@ function publishExternalAPI(angular) {
         $log: $LogProvider,
         $parse: $ParseProvider,
         $rootScope: $RootScopeProvider,
+        $$qPromiseTracker: $$QPromiseTrackerProvider,
         $q: $QProvider,
         $$q: $$QProvider,
         $sce: $SceProvider,

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -263,7 +263,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     return d;
   };
 
-  function Promise() {
+  function Promise(keepTrack) {
     this.$$state = { status: 0 };
 
     // some built-in angular module may use promises when the dependencies are not yet loaded, make sure not to track those

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -254,8 +254,8 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
    *
    * @returns {Deferred} Returns a new instance of deferred.
    */
-  var defer = function(keepTrack) {
-    var d = new Deferred(keepTrack);
+  var defer = function() {
+    var d = new Deferred();
     //Necessary to support unbound execution :/
     d.resolve = simpleBind(d, d.resolve);
     d.reject = simpleBind(d, d.reject);
@@ -263,17 +263,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     return d;
   };
 
-  function Promise(keepTrack) {
+  function Promise() {
     this.$$state = { status: 0 };
 
     // some built-in angular module may use promises when the dependencies are not yet loaded, make sure not to track those
-    if (promiseTracker) {
-      this.keepTrack = keepTrack !== undefined ? keepTrack : true;
-    }
-  
-    if (this.keepTrack === true) {
-      promiseTracker.track(this);
-    }
+    promiseTracker && promiseTracker.track(this);
   }
 
   extend(Promise.prototype, {
@@ -340,8 +334,8 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     nextTick(function() { processQueue(state); });
   }
 
-  function Deferred(keepTrack) {
-    this.promise = new Promise(keepTrack);
+  function Deferred() {
+    this.promise = new Promise();
   }
 
   extend(Deferred.prototype, {
@@ -370,9 +364,8 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
         } else {
           this.promise.$$state.value = val;
           this.promise.$$state.status = 1;
-          if (this.promise.keepTrack) {
-            promiseTracker.untrack(this.promise);
-          }
+
+          promiseTracker && promiseTracker.untrack(this.promise);
           scheduleProcessQueue(this.promise.$$state);
         }
       } catch (e) {
@@ -401,9 +394,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       this.promise.$$state.value = reason;
       this.promise.$$state.status = 2;
 
-      if (this.promise.keepTrack) {
-        promiseTracker.untrack(this.promise);
-      }
+      promiseTracker && promiseTracker.untrack(this.promise);
       scheduleProcessQueue(this.promise.$$state);
     },
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -267,7 +267,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     this.$$state = { status: 0 };
 
     // some built-in angular module may use promises when the dependencies are not yet loaded, make sure not to track those
-    promiseTracker && promiseTracker.track(this);
+    promiseTracker.track(this);
   }
 
   extend(Promise.prototype, {
@@ -365,7 +365,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
           this.promise.$$state.value = val;
           this.promise.$$state.status = 1;
 
-          promiseTracker && promiseTracker.untrack(this.promise);
+          promiseTracker.untrack(this.promise);
           scheduleProcessQueue(this.promise.$$state);
         }
       } catch (e) {
@@ -394,7 +394,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       this.promise.$$state.value = reason;
       this.promise.$$state.status = 2;
 
-      promiseTracker && promiseTracker.untrack(this.promise);
+      promiseTracker.untrack(this.promise);
       scheduleProcessQueue(this.promise.$$state);
     },
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -263,11 +263,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     return d;
   };
 
-  function Promise(keepTrack) {
+  function Promise() {
     this.$$state = { status: 0 };
 
     // some built-in angular module may use promises when the dependencies are not yet loaded, make sure not to track those
-    if (keepTrack || promiseTracker) {
+    if (promiseTracker) {
       this.keepTrack = keepTrack !== undefined ? keepTrack : true;
     }
   
@@ -281,7 +281,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       if (isUndefined(onFulfilled) && isUndefined(onRejected) && isUndefined(progressBack)) {
         return this;
       }
-      var result = new Deferred(false); // do not track the .then() as separate promises
+      var result = new Deferred();
 
       this.$$state.pending = this.$$state.pending || [];
       this.$$state.pending.push([result, onFulfilled, onRejected, progressBack]);
@@ -291,11 +291,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     },
 
     "catch": function(callback) {
-      return this.then(null, callback); // .catch() promises wont count as separate promises by using the .then() callback
+      return this.then(null, callback);
     },
 
     "finally": function(callback, progressBack) {
-      return this.then(function(value) { // .finally() promises wont count as separate promises by using the .then() callback
+      return this.then(function(value) {
         return handleCallback(value, true, callback);
       }, function(error) {
         return handleCallback(error, false, callback);

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -9,25 +9,10 @@
  *
  */
 function $$QPromiseTrackerProvider() {
-    var pendingPromisesCount = 0;
-
-    var trackNewPromise = function(promise) {
-        pendingPromisesCount++;
-    };
-
-    var untrackPromise = function(promise) {
-        pendingPromisesCount--;
-    };
-
-    var getPendingPromisesCount = function() {
-        return pendingPromisesCount;
-    };
-
     this.$get = function() {
         return {
-            track: trackNewPromise,
-            untrack: untrackPromise,
-            getCount: getPendingPromisesCount
+            track: angular.noop,
+            untrack: angular.noop
         };
     }
 }

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -4,7 +4,7 @@
  * @name $$qPromiseTracker
  *
  * @description
- * Service that tracks active promises by tracking and untracking promises as they are created,
+ * Tracks active promises by tracking and untracking promises as they are created,
  * rejected or resolved. 
  *
  */

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -6,6 +6,10 @@
  * @description
  * Tracks active promises by tracking and untracking promises as they are created,
  * rejected or resolved. 
+ * 
+ * By default, this does not track any promises that gets created.
+ * To use this API, one must override the `$$qPromiseTracker` at config time
+ * and provide their own tracking implementation using `$provide`.
  *
  */
 function $$QPromiseTrackerProvider() {

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -1,0 +1,28 @@
+'use strict';
+/**
+ * @ngdoc service
+ * @name $$qPromiseTracker
+ *
+ * @description
+ * Service that tracks active promises by tracking and untracking promises as they are created,
+ * rejected or resolved. 
+ *
+ */
+function $$QPromiseTrackerProvider() {
+    var pendingCount = 0;
+
+    var trackNewPromise = function(promise) {
+        this.pendingCount++;
+    };
+
+    var untrackPromise = function(promise) {
+        this.pendingCount--;
+    };
+
+    this.$get = function() {
+        return {
+            track: trackNewPromise,
+            untrack: untrackPromise
+        };
+    }
+}

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -9,20 +9,25 @@
  *
  */
 function $$QPromiseTrackerProvider() {
-    var pendingCount = 0;
+    var pendingPromisesCount = 0;
 
     var trackNewPromise = function(promise) {
-        pendingCount++;
+        pendingPromisesCount++;
     };
 
     var untrackPromise = function(promise) {
-        pendingCount--;
+        pendingPromisesCount--;
+    };
+
+    var getPendingPromisesCount = function() {
+        return pendingPromisesCount;
     };
 
     this.$get = function() {
         return {
             track: trackNewPromise,
-            untrack: untrackPromise
+            untrack: untrackPromise,
+            getCount: getPendingPromisesCount
         };
     }
 }

--- a/src/ng/qPromiseTracker.js
+++ b/src/ng/qPromiseTracker.js
@@ -12,11 +12,11 @@ function $$QPromiseTrackerProvider() {
     var pendingCount = 0;
 
     var trackNewPromise = function(promise) {
-        this.pendingCount++;
+        pendingCount++;
     };
 
     var untrackPromise = function(promise) {
-        this.pendingCount--;
+        pendingCount--;
     };
 
     this.$get = function() {

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -624,7 +624,7 @@ describe('q', function() {
           expect(log).toEqual(['error(oops!)->reject(oops!)']);
         });
 
-        it('should not be tracked as a separate promise', function() {
+        it('should be tracked as a separate promise', function() {
           var promise = createPromise();
           expect(mockPromiseTracker.trackedPromises.length).toBe(1);
           expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
@@ -633,7 +633,7 @@ describe('q', function() {
                   then(null).
                   then('hello world');
           
-          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.trackedPromises.length).toBe(4);
           expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
         });
 
@@ -683,7 +683,7 @@ describe('q', function() {
           expect(logStr()).toBe('finally1()');
         });
 
-        it('should not be tracked as a separate promise', function() {
+        it('should be tracked as a separate promise', function() {
           var promise = createPromise();
           expect(mockPromiseTracker.trackedPromises.length).toBe(1);
           expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
@@ -693,7 +693,7 @@ describe('q', function() {
                   then('hello world').
                   finally(() => {});
           
-          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.trackedPromises.length).toBe(5);
           expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
         });
 

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -37,7 +37,10 @@ describe('q', function() {
   // The following private functions are used to help with logging for testing invocation of the
   // promise callbacks.
   function _argToString(arg) {
-    return (typeof arg === 'object' && !(arg instanceof Error)) ? toJson(arg) : '' + arg;
+    var argCopy = arg;
+    // Fix for introducting the keepTrack state in promises
+    if(typeof arg === 'object' && arg.keepTrack) { delete argCopy.keepTrack; } 
+    return (typeof arg === 'object' && !(arg instanceof Error)) ? toJson(argCopy) : '' + arg;
   }
 
   function _argumentsToString(args) {
@@ -180,9 +183,19 @@ describe('q', function() {
     }
   };
 
+  var mockPromiseTracker = {
+    trackedPromises: [],
+    untrackedPromises: [],
+    track: function(promise) {
+      mockPromiseTracker.trackedPromises.push(promise);
+    },
+    untrack: function(promise) {
+      mockPromiseTracker.untrackedPromises.push(promise);
+    }
+  };
 
   beforeEach(function() {
-    q = qFactory(mockNextTick.nextTick, noop),
+    q = qFactory(mockNextTick.nextTick, noop, mockPromiseTracker),
     defer = q.defer;
     deferred =  defer();
     promise = deferred.promise;
@@ -199,6 +212,8 @@ describe('q', function() {
   describe('$Q', function() {
     var resolve, reject, resolve2, reject2;
     var createPromise = function() {
+      mockPromiseTracker.trackedPromises = [];
+      mockPromiseTracker.untrackedPromises = [];
       return q(function(resolveFn, rejectFn) {
         if (resolve === null) {
           resolve = resolveFn;
@@ -230,6 +245,10 @@ describe('q', function() {
       /*jshint newcap: true */
     });
 
+    it('should keep track of newly created promises by default', function() {
+      var promise = createPromise();
+      expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+    });
 
     describe('resolve', function() {
       it('should fulfill the promise and execute all success callbacks in the registration order',
@@ -338,6 +357,12 @@ describe('q', function() {
         mockNextTick.flush();
         expect(logStr()).toBe('then1(foo)->resolve(bar); success2(foo)->foo');
       });
+
+      it('should untrack resolved promises', function() {
+        var promise = createPromise();
+        resolve(true);
+        expect(mockPromiseTracker.untrackedPromises.length).toBe(1);
+      });
     });
 
 
@@ -428,6 +453,12 @@ describe('q', function() {
         reject('detached');
         mockNextTick.flush();
         expect(logStr()).toBe('error(detached)->reject(detached)');
+      });
+
+      it('should untrack resolved promises', function() {
+        var promise = createPromise();
+        reject(true);
+        expect(mockPromiseTracker.untrackedPromises.length).toBe(1);
       });
     });
 
@@ -593,6 +624,19 @@ describe('q', function() {
           expect(log).toEqual(['error(oops!)->reject(oops!)']);
         });
 
+        it('should not be tracked as a separate promise', function() {
+          var promise = createPromise();
+          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
+          
+          promise.then(1).
+                  then(null).
+                  then('hello world');
+          
+          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
+        });
+
         it('should forward success resolution when success callbacks are not functions', function() {
           var promise = createPromise();
           resolve('yay!');
@@ -637,6 +681,20 @@ describe('q', function() {
           resolve('foo');
           mockNextTick.flush();
           expect(logStr()).toBe('finally1()');
+        });
+
+        it('should not be tracked as a separate promise', function() {
+          var promise = createPromise();
+          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
+          
+          promise.then(1).
+                  then(null).
+                  then('hello world').
+                  finally(() => {});
+          
+          expect(mockPromiseTracker.trackedPromises.length).toBe(1);
+          expect(mockPromiseTracker.untrackedPromises.length).toBe(0);
         });
 
         describe("when the promise is fulfilled", function() {
@@ -698,6 +756,18 @@ describe('q', function() {
 
                 expect(logStr()).toBe('finally1()->{}; success2(foo)->foo');
               });
+
+              it("should untrack the promise", function() {
+                var promise = createPromise();
+                var promise2 = createPromise();
+                var untrackBefore = mockPromiseTracker.untrackedPromises.length;
+                resolve2('bar');
+                 promise['finally'](fin(1, promise))
+                       .then(success(2));
+                 resolve('foo');
+                mockNextTick.flush();
+                 expect(mockPromiseTracker.untrackedPromises.length).toBeGreaterThan(untrackBefore);
+              });
             });
 
             describe("that is rejected", function() {
@@ -712,6 +782,18 @@ describe('q', function() {
                 mockNextTick.flush();
                 expect(logStr()).toBe('finally1()->{}; error1(bar)->reject(bar)');
               });
+
+              it("should untrack the promise", function() {
+                var promise = createPromise();
+                var promise2 = createPromise();
+                var untrackBefore = mockPromiseTracker.untrackedPromises.length;
+                reject2('bar');
+                promise['finally'](fin(1, promise2))
+                       .then(success(2), error(1));
+                resolve('foo');
+                mockNextTick.flush();
+                 expect(mockPromiseTracker.untrackedPromises.length).toBeGreaterThan(untrackBefore);
+              });
             });
 
           });
@@ -724,6 +806,15 @@ describe('q', function() {
               resolve('foo');
               mockNextTick.flush();
               expect(logStr()).toBe('finally1()->throw(exception); error2(exception)->reject(exception)');
+            });
+
+            it("should untrack the promise", function() {
+              var promise = createPromise();
+              promise['finally'](fin(1, "exception", true))
+                     .then(success(1), error(2));
+              resolve('foo');
+              mockNextTick.flush();
+              expect(mockPromiseTracker.trackedPromises.length).toBe(mockPromiseTracker.untrackedPromises.length);
             });
           });
 
@@ -810,6 +901,11 @@ describe('q', function() {
       expect(deferred.reject).toBeDefined();
     });
 
+    it('should keep track of the new deferred', function() {
+      var promisesLength = mockPromiseTracker.trackedPromises.length;
+      defer();
+      expect(mockPromiseTracker.trackedPromises.length).toBe(promisesLength + 1);
+    });
 
     describe('resolve', function() {
       it('should fulfill the promise and execute all success callbacks in the registration order',
@@ -821,6 +917,11 @@ describe('q', function() {
         deferred.resolve('foo');
         mockNextTick.flush();
         expect(logStr()).toBe('success1(foo)->foo; success2(foo)->foo');
+      });
+
+      if('should untrack whenever deferred object gets resolved', function() {
+        deferred.resolve('foo');
+        expect(mockPromiseTracker.untrackedPromises.length).toBe(1);
       });
 
 
@@ -949,6 +1050,11 @@ describe('q', function() {
         expect(logStr()).toBe('error1(foo)->reject(foo); error2(foo)->reject(foo)');
       });
 
+
+      if('should untrack whenever deferred object gets rejected', function() {
+        deferred.resolve('foo');
+        expect(mockPromiseTracker.untrackedPromises.length).toBe(1);
+      });
 
       it('should do nothing if a promise was previously resolved', function() {
         promise.then(success(1), error(1));

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -757,13 +757,12 @@ describe('q', function() {
               it("should untrack the promise", function() {
                 var promise = createPromise();
                 var promise2 = createPromise();
-                var untrackBefore = mockPromiseTracker.untrackedPromises.length;
                 resolve2('bar');
                  promise['finally'](fin(1, promise))
                        .then(success(2));
                  resolve('foo');
                 mockNextTick.flush();
-                 expect(mockPromiseTracker.untrackedPromises.length).toBeGreaterThan(untrackBefore);
+                expect(mockPromiseTracker.untrackedPromises.length).toBe(8);
               });
             });
 

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -37,10 +37,7 @@ describe('q', function() {
   // The following private functions are used to help with logging for testing invocation of the
   // promise callbacks.
   function _argToString(arg) {
-    var argCopy = arg;
-    // Fix for introducting the keepTrack state in promises
-    if(typeof arg === 'object' && arg.keepTrack) { delete argCopy.keepTrack; } 
-    return (typeof arg === 'object' && !(arg instanceof Error)) ? toJson(argCopy) : '' + arg;
+    return (typeof arg === 'object' && !(arg instanceof Error)) ? toJson(arg) : '' + arg;
   }
 
   function _argumentsToString(args) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
A new promise tracker service that helps user to track promises that are created, resolved and rejected. This will ultimately help to track pending / lingering promises that never end up getting resolved / rejected.

**What is the current behavior? (You can also link to an open issue here)**
There's no tracking mechanism enabling users to track promises.


**What is the new behavior (if this is a feature change)?**
There is a new `$$qPromiseTracker` service which exposes a `track()` and `untrack()` method and is used in `qFactory` whenever a promise gets created / resolved / rejected.

One can use this feature by overriding the `$$qPromiseTracker` factory that gets used in the `$qFactory` at config time as follows:  

```javascript
app.config(($provide) => {
    let promiseCount = 0;
    $provide.factory('$$qPromiseTracker', () => {
        return {
            track: (promise) => promiseCount++,
            untrack: (promise) => promiseCount--
        }
    });
});
```