### PR TITLE
Add support for rejecting deferred promises silently

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -398,8 +398,9 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     },
 
     rejectSilently: function() {
+      if (this.promise.$$state.status) return;
       this.promise.$$state.isSilentReject = true;
-      this.reject();
+      this.$$reject(reason);
     },
 
     reject: function(reason) {

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -117,6 +117,8 @@
  *   constructed via `$q.reject`, the promise will be rejected instead.
  * - `reject(reason)` – rejects the derived promise with the `reason`. This is equivalent to
  *   resolving it with a rejection constructed via `$q.reject`.
+ * - `rejectSilently()` – rejects the derived promise. This is equivalent to reject with the 
+ *   exception that it won't invoke the errorCallback registered for the promise.
  * - `notify(value)` - provides updates on the status of the promise's execution. This may be called
  *   multiple times before the promise is either resolved or rejected.
  *
@@ -259,15 +261,13 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     //Necessary to support unbound execution :/
     d.resolve = simpleBind(d, d.resolve);
     d.reject = simpleBind(d, d.reject);
+    d.rejectSilently = simpleBind(d, d.rejectSilently);
     d.notify = simpleBind(d, d.notify);
     return d;
   };
 
   function Promise() {
     this.$$state = { status: 0 };
-
-    // some built-in angular module may use promises when the dependencies are not yet loaded, make sure not to track those
-    promiseTracker.track(this);
   }
 
   extend(Promise.prototype, {
@@ -314,7 +314,9 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       deferred = pending[i][0];
       fn = pending[i][state.status];
       try {
-        if (isFunction(fn)) {
+        if (state.isSilentReject) {
+          deferred.rejectSilently();
+        } else if (isFunction(fn)) {
           deferred.resolve(fn(state.value));
         } else if (state.status === 1) {
           deferred.resolve(state.value);
@@ -322,7 +324,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
           deferred.reject(state.value);
         }
       } catch (e) {
-        deferred.reject(e);
+        if (state.isSilentReject) {
+          deferred.rejectSilently();
+        } else {
+          deferred.reject(e);
+        }
         exceptionHandler(e);
       }
     }
@@ -336,6 +342,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
 
   function Deferred() {
     this.promise = new Promise();
+    promiseTracker.track(this);
   }
 
   extend(Deferred.prototype, {
@@ -365,7 +372,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
           this.promise.$$state.value = val;
           this.promise.$$state.status = 1;
 
-          promiseTracker.untrack(this.promise);
+          promiseTracker.untrack(this);
           scheduleProcessQueue(this.promise.$$state);
         }
       } catch (e) {
@@ -385,6 +392,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       }
     },
 
+    rejectSilently: function() {
+      this.promise.$$state.isSilentReject = true;
+      this.reject();
+    },
+
     reject: function(reason) {
       if (this.promise.$$state.status) return;
       this.$$reject(reason);
@@ -394,7 +406,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
       this.promise.$$state.value = reason;
       this.promise.$$state.status = 2;
 
-      promiseTracker.untrack(this.promise);
+      promiseTracker.untrack(this);
       scheduleProcessQueue(this.promise.$$state);
     },
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -118,7 +118,8 @@
  * - `reject(reason)` – rejects the derived promise with the `reason`. This is equivalent to
  *   resolving it with a rejection constructed via `$q.reject`.
  * - `rejectSilently()` – rejects the derived promise. This is equivalent to reject with the 
- *   exception that it won't invoke the errorCallback registered for the promise.
+ *   exception that it won't invoke the errorCallback registered for the promise. In addition it
+ *   rejects the promise chain syncronously
  * - `notify(value)` - provides updates on the status of the promise's execution. This may be called
  *   multiple times before the promise is either resolved or rejected.
  *
@@ -337,7 +338,11 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
   function scheduleProcessQueue(state) {
     if (state.processScheduled || !state.pending) return;
     state.processScheduled = true;
-    nextTick(function() { processQueue(state); });
+    if (state.isSilentReject) {
+      processQueue(state);
+    } else {
+      nextTick(function() { processQueue(state); });
+    }
   }
 
   function Deferred() {

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -400,7 +400,7 @@ function qFactory(nextTick, exceptionHandler, promiseTracker) {
     rejectSilently: function() {
       if (this.promise.$$state.status) return;
       this.promise.$$state.isSilentReject = true;
-      this.$$reject(reason);
+      this.$$reject();
     },
 
     reject: function(reason) {

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -1140,6 +1140,30 @@ describe('q', function() {
       });
 
 
+      it('reject and rejectSilently should follow the same chain rejection', function() {
+        mockPromiseTracker.untrackedPromises = [];
+        var deferred1 = defer();
+        deferred1.promise
+        .then(() => {}).catch((err) => {})
+        .then(() => {}).catch((err) => {});
+
+        deferred1.reject();
+        mockNextTick.flush();
+        var rejectUntrackedCount = mockPromiseTracker.untrackedPromises.length;
+
+        mockPromiseTracker.untrackedPromises = [];
+        var deferred2 = defer();
+        deferred2.promise
+        .then(() => {}).catch((err) => {})
+        .then(() => {}).catch((err) => {});
+
+        deferred2.rejectSilently();
+        mockNextTick.flush();
+        var rejectSilentlyUntrackedCount = mockPromiseTracker.untrackedPromises.length;
+
+        expect(rejectSilentlyUntrackedCount).toBe(rejectUntrackedCount);
+      });
+
       it('should do nothing if a promise was previously resolved', function() {
         promise.then(success(1), error(1));
         expect(logStr()).toBe('');

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -895,6 +895,7 @@ describe('q', function() {
       expect(deferred.promise).toBeDefined();
       expect(deferred.resolve).toBeDefined();
       expect(deferred.reject).toBeDefined();
+      expect(deferred.rejectSilently).toBeDefined();
     });
 
     it('should keep track of the new deferred', function() {
@@ -1122,6 +1123,74 @@ describe('q', function() {
         rejector('detached');
         mockNextTick.flush();
         expect(logStr()).toBe('error(detached)->reject(detached)');
+      });
+    });
+
+
+    describe('rejectSilently', function() {
+      it('should reject the promise and should not execute error callbacks',
+          function() {
+        promise.then(success(), error(1));
+        promise.then(success(), error(2));
+        expect(logStr()).toBe('');
+
+        deferred.rejectSilently();
+        mockNextTick.flush();
+        expect(logStr()).toBe('');
+      });
+
+
+      it('should do nothing if a promise was previously resolved', function() {
+        promise.then(success(1), error(1));
+        expect(logStr()).toBe('');
+
+        deferred.resolve('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('success1(foo)->foo');
+
+        log = [];
+        deferred.rejectSilently();
+        deferred.resolve('baz');
+        expect(mockNextTick.queue.length).toBe(0);
+        expect(logStr()).toBe('');
+
+        promise.then(success(2), error(2));
+        expect(logStr()).toBe('');
+        mockNextTick.flush();
+        expect(logStr()).toBe('');
+      });
+
+
+      it('should do nothing if a promise was previously rejected', function() {
+        promise.then(success(1), error(1));
+        expect(logStr()).toBe('');
+
+        deferred.reject('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('error1(foo)->reject(foo)');
+
+        log = [];
+        deferred.rejectSilently();
+        deferred.resolve('baz');
+        expect(mockNextTick.queue.length).toBe(0);
+        expect(logStr()).toBe('');
+
+        promise.then(success(2), error(2));
+        expect(logStr()).toBe('');
+        mockNextTick.flush();
+        expect(logStr()).toBe('');
+      });
+
+
+      it('should not call the error callback in the next turn', function() {
+        promise.then(success(), error());
+        expect(logStr()).toBe('');
+
+        deferred.rejectSilently();
+        expect(logStr()).toBe('');
+
+        mockNextTick.flush();
+        expect(logStr()).toBe('');
       });
     });
 
@@ -2084,7 +2153,7 @@ describe('q', function() {
 
 
     beforeEach(function() {
-      q = qFactory(mockNextTick.nextTick, mockExceptionLogger.logger),
+      q = qFactory(mockNextTick.nextTick, mockExceptionLogger.logger, mockPromiseTracker),
       defer = q.defer;
       deferred =  defer();
       promise = deferred.promise;
@@ -2198,7 +2267,7 @@ describe('q', function() {
       errorSpy = jasmine.createSpy('errorSpy');
 
 
-      q = qFactory(mockNextTick.nextTick, exceptionExceptionSpy);
+      q = qFactory(mockNextTick.nextTick, exceptionExceptionSpy, mockPromiseTracker);
       deferred = q.defer();
     });
 


### PR DESCRIPTION
feat(q): Adding support for rejecting deferred promises silently and updating the code to track deferred objects instead of the promises.

 - Added rejectSilently which rejects promise without invoking any registered error callbacks
 - Added UTs for the newly exposed API
 - Change the promise tracking code to track deferred objects instead of the promise object.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature. A new API rejectSilently is introduced on q deferred. This change is required so we can track the promises and reject them silently when required. Currently we need that support for MTMA feature where during a switch all the promises will be rejected silently


**What is the current behavior? (You can also link to an open issue here)**
Currently there is no way to reject a promise silently, i.e. when a promise is rejected any registered error callbacks for that promise is executed.


**What is the new behavior (if this is a feature change)?**
This change adds the support by introducing a new API on Deferred called rejectSilently. Any deferred promise rejected using rejectSilently will reject the promise without invoking any of the error callbacks on that promise. It doesn't change the existing behavior and reject API works as it is today.

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

