### PR TITLE
Bucketize -1 error with timeout, error and abort messages

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -109,13 +109,13 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       var requestError = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, 'Error');
+        completeRequest(callback, -1, null, null, 'UnknownError');
       };
 
       var requestAbort = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, isTimedOut ? 'Timeout' : 'Abort');
+        completeRequest(callback, -1, null, null, isTimedOut ? 'Timeout' : 'UnknownAbort');
         isTimedOut = false;
       };
 

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -105,14 +105,22 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             statusText);
       };
 
+      var isTimedOut = false;
       var requestError = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, '');
+        completeRequest(callback, -1, null, null, 'Error');
+      };
+
+      var requestAbort = function() {
+        // The response is always empty
+        // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
+        completeRequest(callback, -1, null, null, isTimedOut ? 'Timeout' : 'Abort');
+        isTimedOut = false;
       };
 
       xhr.onerror = requestError;
-      xhr.onabort = requestError;
+      xhr.onabort = requestAbort;
 
       forEach(eventHandlers, function(value, key) {
           xhr.addEventListener(key, value);
@@ -155,7 +163,10 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
     function timeoutRequest() {
       jsonpDone && jsonpDone();
-      xhr && xhr.abort();
+      if (xhr) {
+        isTimedOut = true;
+        xhr.abort();
+      }
     }
 
     function completeRequest(callback, status, response, headersString, statusText) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix


**What is the current behavior? (You can also link to an open issue here)**
As of today, when chrome xhr error comes or request is aborted then angular fails xhr with result code -1, but there is no clue in the failed response weather it is a chrome error or a timeout or abort due to any other reason. Due to this we are not able to measure the impact of -1 errors.


**What is the new behavior (if this is a feature change)?**
Along with failing response result code -1, we will also send the fail message one of Error, Timeout or Abort. We will be able to send error vs timeout in http telemetry now.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [done] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [done] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**Other information**:

